### PR TITLE
Laravel 5.3.15 Removed AuthorizesResources

### DIFF
--- a/src/ied3vil/LanguageSwitcher/LanguageSwitcherController.php
+++ b/src/ied3vil/LanguageSwitcher/LanguageSwitcherController.php
@@ -13,7 +13,7 @@ use ied3vil\LanguageSwitcher\Facades\LanguageSwitcher as Switcher;
 class LanguageSwitcherController extends BaseController
 {
 
-    use AuthorizesRequests, AuthorizesResources, DispatchesJobs, ValidatesRequests;
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
     /**
      * Set the language and redirect


### PR DESCRIPTION
Error:

Im getting an error when doing a route list command 
php artisan route:list

PHP Fatal error:  Trait 'Illuminate\Foundation\Auth\Access\AuthorizesResources' not found in /home/vagrant/Code/***/vendor/ied3vil/language-switcher/src/ied3vil/LanguageSwitcher/LanguageSwitcherController.php on line 16

  [Symfony\Component\Debug\Exception\FatalErrorException]
  Trait 'Illuminate\Foundation\Auth\Access\AuthorizesResources' not found

From DOCS:
The AuthorizesResources Trait

The AuthorizesResources trait has been merged with the AuthorizesRequests trait. You should remove the AuthorizesResources trait from your app/Http/Controllers/Controller.php file.
