### PR TITLE
use only url path for getLocalBack() method

### DIFF
--- a/src/ied3vil/LanguageSwitcher/LanguageSwitcher.php
+++ b/src/ied3vil/LanguageSwitcher/LanguageSwitcher.php
@@ -54,7 +54,7 @@ class LanguageSwitcher
      */
     public function getLocalBack($language)
     {
-        $backUrl = redirect()->back()->getTargetUrl();
+        $backUrl = parse_url(redirect()->back()->getTargetUrl(), PHP_URL_PATH);
         $current = $this->getCurrentLanguage();
         $start = strpos($backUrl, $current);
         $count = strlen($current);


### PR DESCRIPTION
Use only the path for `getLocalBack()` method otherwise if the domain contains language slug the `if` check in method fails and redirect ULR doesn't get updated. 

**EXAMPLE**
if the `$backUrl` is https://messenger.com/en/ and the `$current` is `en` then the first instance of `en` is in `messENger` and not in the path. That causes the `if` to fail and therefor redirect url doesn't get changed and the user is just redirected back to the initial URL. 